### PR TITLE
Updating Berksfile to use https instead of git when cloning for chef-ser...

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,5 +6,5 @@ cookbook 'chef-server-12',
   path: 'vendor/chef-server-12'
 
 cookbook 'chef-server-ingredient',
-  git: 'git@github.com:opscode-cookbooks/chef-server-ingredient.git',
+  git: 'https://github.com/opscode-cookbooks/chef-server-ingredient.git',
   branch: 'master'


### PR DESCRIPTION
Changes the Berksfile to use https:// instead of git:  The change has been tested and works as expected.
